### PR TITLE
Fix error on campaign created

### DIFF
--- a/frontend/packages/react-app/src/components/pages/CreateUUIDCampaignPage.tsx
+++ b/frontend/packages/react-app/src/components/pages/CreateUUIDCampaignPage.tsx
@@ -196,17 +196,26 @@ const CreateUUIDCampaignPage: React.FC<CreateUUIDCampaignPageProps> = ({
           if (result.status !== 1) {
             return;
           }
-          if (result.events && result.events[4].args) {
-            const campaignAddress = result.events[4].args.campaign;
-            distributorFormDispatch({
-              type: "createdCampaignAddress:set",
-              payload: { address: campaignAddress },
-            });
-            distributorFormDispatch({
-              type: "step:set",
-              payload: { stepNo: 4 },
-            });
+          if (result.events == undefined) {
+            return;
           }
+          const campaignCreatedEvent = result.events.find(
+            (event) =>
+              event.event === "CreateCampaign" &&
+              event.address.toLowerCase() === distributorAddress.toLowerCase()
+          );
+          if (campaignCreatedEvent === undefined) {
+            return;
+          }
+          const campaignAddress: string = campaignCreatedEvent.args?.campaign;
+          distributorFormDispatch({
+            type: "createdCampaignAddress:set",
+            payload: { address: campaignAddress.toLowerCase() },
+          });
+          distributorFormDispatch({
+            type: "step:set",
+            payload: { stepNo: 4 },
+          });
         });
       });
     },

--- a/frontend/packages/react-app/src/components/pages/CreateWalletCampaignPage.tsx
+++ b/frontend/packages/react-app/src/components/pages/CreateWalletCampaignPage.tsx
@@ -196,14 +196,24 @@ const CreateWalletCampaignPage: React.FC<CreateWalletCampaignPageProps> = ({
           return;
         }
         transaction.wait().then((result) => {
-          if (result.status === 1) {
-            if (result.events && result.events[4].args) {
-              const campaignAddress = result.events[4].args.campaign;
-              props.history.push(
-                window.location.pathname + `/campaigns/${campaignAddress}`
-              );
-            }
+          if (result.status !== 1) {
+            return;
           }
+          if (result.events == undefined) {
+            return;
+          }
+          const campaignCreatedEvent = result.events.find(
+            (event) =>
+              event.event === "CreateCampaign" &&
+              event.address.toLowerCase() === distributorAddress.toLowerCase()
+          );
+          if (campaignCreatedEvent === undefined) {
+            return;
+          }
+          const campaignAddress: string = campaignCreatedEvent.args?.campaign;
+          props.history.push(
+            window.location.pathname + `/campaigns/${campaignAddress}`
+          );
         });
       });
     },


### PR DESCRIPTION
An error was occurred because a different length of events is emitted depends on a ERC20 token. 
Fix a bug with getting `CreateCampaign` event by filtering with distributor address and event name. 