### PR TITLE
Fix fetched invalid json if content is large

### DIFF
--- a/functions/merkle-tree/functions/generator/src/app.ts
+++ b/functions/merkle-tree/functions/generator/src/app.ts
@@ -23,6 +23,7 @@ import {
 } from "@iroiro/merkle-distributor";
 import { S3 } from "aws-sdk";
 import { parseStringBalanceMap } from "@iroiro/merkle-distributor/dist/parse-string-balance-map";
+import fetch from "node-fetch";
 const s3 = new S3();
 const ipfsClient = require("ipfs-http-client");
 const ipfs = ipfsClient("https://gateway.pinata.cloud/");
@@ -44,17 +45,17 @@ exports.lambdaHandler = async (event: Input) => {
   const type: TargetType = event["type"];
 
   let merkleTree: MerkleDistributorInfo;
+  const url = `https://gateway.pinata.cloud/ipfs/${inputCid}`;
+  const response = await fetch(url);
   switch (type) {
     case "address":
       // error handling
-      const balanceMap = (await getFile(inputCid)) as BalanceMapOldFormat;
+      const balanceMap = (await response.json()) as BalanceMapOldFormat;
       merkleTree = parseBalanceMap(balanceMap);
       break;
     case "keccak256":
       // error handling
-      const stringBalanceMap = (await getFile(
-        inputCid
-      )) as StringBalanceMapOldFormat;
+      const stringBalanceMap = (await response.json()) as StringBalanceMapOldFormat;
       merkleTree = parseStringBalanceMap(stringBalanceMap);
       break;
     default:

--- a/functions/merkle-tree/functions/generator/tests/unit/test-handler.spec.ts
+++ b/functions/merkle-tree/functions/generator/tests/unit/test-handler.spec.ts
@@ -60,6 +60,23 @@ describe("Tests Generator", function () {
     );
   });
 
+  it("1000 targets", async () => {
+    event = {
+      cid: "QmbE1NKLTsSvNAeECC5KnXxG8nFmaP5XAoY67GbDZHb56W",
+      type: "keccak256",
+    };
+    const result = await app.lambdaHandler(event, context);
+    console.debug("result", result);
+
+    expect(result).to.be.an("object");
+    expect(result.bucket).to.be.an("string");
+    expect(result.bucket).to.equal(process.env.MERKLE_TREE_BUCKET);
+    expect(result.key).to.be.an("string");
+    expect(result.key).to.equal(
+      "0xd37bdc738b33d45e4106dcc00167b4a3c4390ee39741d0bc46ac4e1f5602523d.json"
+    );
+  });
+
   it("throws an error if input does not have field", async () => {
     event = {
       cid: "QmbE1NKLTsSvNAeECC5KnXxG8nFmaP5XAoY67GbDZHb56W",

--- a/functions/merkle-tree/functions/input-generator/package.json
+++ b/functions/merkle-tree/functions/input-generator/package.json
@@ -14,6 +14,7 @@
     "axios": "^0.21.1",
     "ethers": "^5.0.26",
     "ipfs-http-client": "48.1.2",
+    "node-fetch": "^2.6.1",
     "typescript": "^4.1.3",
     "web3": "^1.3.1",
     "web3-utils": "^1.3.1"
@@ -25,6 +26,7 @@
   "devDependencies": {
     "@types/chai": "^4.2.14",
     "@types/mocha": "^8.2.0",
+    "@types/node-fetch": "^2.5.8",
     "@types/web3": "^1.2.2",
     "chai": "^4.2.0",
     "dotenv-cli": "^4.0.0",

--- a/functions/merkle-tree/functions/input-generator/tests/unit/test-handler.spec.ts
+++ b/functions/merkle-tree/functions/input-generator/tests/unit/test-handler.spec.ts
@@ -29,6 +29,8 @@ const addressTargetsCid = "QmVrBcK6WZvcKvnJXLq1RM8fVkyAdiDXJFvfXxCtQF73MX";
 const invalidAddressTargetsCid =
   "QmZWoyBX9Xe9osN9nj1nWYXdm2akLuTcbpWJ1AZaKPNWbT";
 const keccak256TargetsCid = "QmVujr4pE8wfjjjHHFqmivg1otenc4AAgrLzsx4dkT5YvM";
+const thousandKeccak256TargetsCid =
+  "QmTvMZwdnxZdrKWrpuRmVAvrqCiSbgWsf3xZCyZv9RcfUx";
 const invalidKeccakTargetsCid =
   "QmTgnu6GSJUR3bSJjkibtDDbBZjRKxfSVxWj12MjEPSmrH";
 const invalidFormatCid = "QmVLdXh64DftwGmj5AZLZJUVCzAz4TJRPEcgTD8urxGQMo";
@@ -108,7 +110,24 @@ describe("Tests Input Generator", function () {
         "QmbE1NKLTsSvNAeECC5KnXxG8nFmaP5XAoY67GbDZHb56W"
       );
       expect(result.type).to.be.an("string");
-      expect(result.type).to.equal("address");
+      expect(result.type).to.equal("keccak256");
+    });
+
+    it("1000 targets", async () => {
+      event = {
+        cid: thousandKeccak256TargetsCid,
+        amount: 100,
+      };
+      const result = await app.lambdaHandler(event, context);
+      console.debug("result: ", result);
+
+      expect(result).to.be.an("object");
+      expect(result.cid).to.be.an("string");
+      expect(result.cid).to.equal(
+        "QmNrsPQwKqvTxCw6DQoXb9Sr1PMwvEiCaCKQ1G7sWFHpy2"
+      );
+      expect(result.type).to.be.an("string");
+      expect(result.type).to.equal("keccak256");
     });
 
     describe("failed cases", () => {

--- a/functions/merkle-tree/yarn.lock
+++ b/functions/merkle-tree/yarn.lock
@@ -409,6 +409,14 @@
   resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-8.2.0.tgz#3eb56d13a1de1d347ecb1957c6860c911704bc44"
   integrity sha512-/Sge3BymXo4lKc31C8OINJgXLaw+7vL1/L1pGiBNpGrBiT8FQiaFpSYV0uhTaG4y78vcMBTMFsWaHDvuD+xGzQ==
 
+"@types/node-fetch@^2.5.8":
+  version "2.5.8"
+  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.5.8.tgz#e199c835d234c7eb0846f6618012e558544ee2fb"
+  integrity sha512-fbjI6ja0N5ZA8TV53RUqzsKNkl9fv8Oj3T7zxW7FGv1GSH7gwJaNF8dzCjrqKaxKeUpTz4yT1DaJFq/omNpGfw==
+  dependencies:
+    "@types/node" "*"
+    form-data "^3.0.0"
+
 "@types/node@*", "@types/node@^14.14.21":
   version "14.14.22"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.22.tgz#0d29f382472c4ccf3bd96ff0ce47daf5b7b84b18"
@@ -3544,7 +3552,7 @@ node-addon-api@^2.0.0:
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-2.0.2.tgz#432cfa82962ce494b132e9d72a15b29f71ff5d32"
   integrity sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==
 
-node-fetch@^2.6.0:
+node-fetch@^2.6.0, node-fetch@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==


### PR DESCRIPTION
When JSON content is large, invalid string is contained in JSON fetched with ipfs client. 
So changed fetching method from ipfs client to HTTP GET request. 