### PR TITLE
Fix distributor type is not displayed

### DIFF
--- a/frontend/packages/react-app/src/components/molecules/CampaignListTable/index.tsx
+++ b/frontend/packages/react-app/src/components/molecules/CampaignListTable/index.tsx
@@ -29,7 +29,7 @@ import {
 } from "@material-ui/core";
 import { Link } from "react-router-dom";
 import { CampaignInfo, Campaigns } from "../../../interfaces";
-import distributors from "../../../utils/distributors";
+import distributors, { getDistributorType } from "../../../utils/distributors";
 import WalletButton from "../../atoms/WalletButton";
 import styled from "styled-components";
 import theme from "../../../theme/mui-theme";
@@ -45,11 +45,12 @@ interface DistributorProps {
 
 function DistributorName(props: DistributorProps) {
   const { campaign } = props;
-  const result = distributors.filter(
-    (distributor) => distributor.id === campaign.distributor.id
+  const result = distributors.find(
+    (distributor) =>
+      distributor.id.toLowerCase() === campaign.distributor.id.toLowerCase()
   );
 
-  return <Typography>{result[0].distributorMetadata.name}</Typography>;
+  return <Typography>{getDistributorType(result?.type ?? "")}</Typography>;
 }
 
 export interface CampaignListTableProps {

--- a/frontend/packages/react-app/src/components/organisms/TokenCampaignDetail/index.tsx
+++ b/frontend/packages/react-app/src/components/organisms/TokenCampaignDetail/index.tsx
@@ -21,6 +21,7 @@ import { Typography, Box, Link } from "@material-ui/core";
 import CampaignStatusChip from "../../atoms/CampaignStatusChip";
 import theme from "../../../theme/mui-theme";
 import { useEffect, useState } from "react";
+import distributors from "../../../utils/distributors";
 
 export interface TokenCampaignDetailProps {
   readonly campaign: CampaignInfo;
@@ -30,16 +31,18 @@ const TokenCampaignDetail: React.FC<TokenCampaignDetailProps> = ({
   campaign,
 }) => {
   const [distributorType, setDistributorType] = useState("");
+  const distributor = distributors.find(
+    (distributor) =>
+      distributor.id.toLowerCase() === campaign.distributor.id.toLowerCase()
+  );
   useEffect(() => {
-    switch (campaign.distributor.type) {
+    switch (distributor?.type) {
       case "wallet":
         setDistributorType("Wallet Address Type");
         break;
       case "uuid":
-        setDistributorType("UUID Type");
-        break;
       case "email":
-        setDistributorType("Email Address Type");
+        setDistributorType("URL/Email Type");
         break;
       default:
         setDistributorType(campaign.distributor.type);

--- a/frontend/packages/react-app/src/components/organisms/TokenCampaignDetail/index.tsx
+++ b/frontend/packages/react-app/src/components/organisms/TokenCampaignDetail/index.tsx
@@ -21,7 +21,7 @@ import { Typography, Box, Link } from "@material-ui/core";
 import CampaignStatusChip from "../../atoms/CampaignStatusChip";
 import theme from "../../../theme/mui-theme";
 import { useEffect, useState } from "react";
-import distributors from "../../../utils/distributors";
+import distributors, { getDistributorType } from "../../../utils/distributors";
 
 export interface TokenCampaignDetailProps {
   readonly campaign: CampaignInfo;
@@ -31,22 +31,13 @@ const TokenCampaignDetail: React.FC<TokenCampaignDetailProps> = ({
   campaign,
 }) => {
   const [distributorType, setDistributorType] = useState("");
-  const distributor = distributors.find(
-    (distributor) =>
-      distributor.id.toLowerCase() === campaign.distributor.id.toLowerCase()
-  );
+
   useEffect(() => {
-    switch (distributor?.type) {
-      case "wallet":
-        setDistributorType("Wallet Address Type");
-        break;
-      case "uuid":
-      case "email":
-        setDistributorType("URL/Email Type");
-        break;
-      default:
-        setDistributorType(campaign.distributor.type);
-    }
+    const distributor = distributors.find(
+      (distributor) =>
+        distributor.id.toLowerCase() === campaign.distributor.id.toLowerCase()
+    );
+    setDistributorType(getDistributorType(distributor?.type ?? ""));
   }, [campaign]);
 
   return (

--- a/frontend/packages/react-app/src/utils/distributors.ts
+++ b/frontend/packages/react-app/src/utils/distributors.ts
@@ -15,7 +15,7 @@
  *     along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-import { Distributor } from "../interfaces";
+import { Distributor, DistributorTypes } from "../interfaces";
 
 // ID must be lowercase
 const distributors: Distributor[] = [
@@ -75,5 +75,17 @@ const distributors: Distributor[] = [
     id: dist.id.toLowerCase(),
   };
 });
+
+export const getDistributorType = (type: string) => {
+  switch (type) {
+    case "wallet":
+      return "Wallet Address Type";
+    case "uuid":
+    case "email":
+      return "URL/Email Type";
+    default:
+      return "";
+  }
+};
 
 export default distributors;

--- a/frontend/packages/react-app/src/utils/distributors.ts
+++ b/frontend/packages/react-app/src/utils/distributors.ts
@@ -79,10 +79,10 @@ const distributors: Distributor[] = [
 export const getDistributorType = (type: string): string => {
   switch (type) {
     case "wallet":
-      return "Wallet Address Type";
+      return "Wallet Address Distributor";
     case "uuid":
     case "email":
-      return "URL/Email Type";
+      return "URL/Email Distributor";
     default:
       return "";
   }

--- a/frontend/packages/react-app/src/utils/distributors.ts
+++ b/frontend/packages/react-app/src/utils/distributors.ts
@@ -76,7 +76,7 @@ const distributors: Distributor[] = [
   };
 });
 
-export const getDistributorType = (type: string) => {
+export const getDistributorType = (type: string): string => {
   switch (type) {
     case "wallet":
       return "Wallet Address Type";


### PR DESCRIPTION
Fix distributor type of Email campaign is displayed as URL campaign. 
Update to display type as "URL/Email Type"