### PR TITLE
Update uploading button to shown always

### DIFF
--- a/frontend/packages/react-app/src/components/organisms/UploadEmailCsvPane/index.tsx
+++ b/frontend/packages/react-app/src/components/organisms/UploadEmailCsvPane/index.tsx
@@ -29,7 +29,6 @@ import {
   MenuItem,
   Select,
 } from "@material-ui/core";
-import { DISTRIBUTOR_ACTIONS } from "../../../reducers/distributorForm";
 import { EMAIL_ACTIONS, EmailState } from "../../../reducers/email";
 import CSVReader from "react-csv-reader";
 import styled from "styled-components";
@@ -58,65 +57,64 @@ const UploadEmailCsvPane: React.FC<TargetsProps> = ({
   return (
     <>
       <Box>
+        <Box my={2}>
+          <Box display="flex" alignItems="baseline" mb={1}>
+            <Typography variant={"caption"} style={{ paddingRight: 8 }}>
+              File type:
+            </Typography>
+            <Typography variant={"body1"}>CSV</Typography>
+          </Box>
+          <Box display="flex" alignItems="baseline" mb={1}>
+            <Typography variant={"caption"} style={{ paddingRight: 8 }}>
+              Email number limit:
+            </Typography>
+            <Typography variant={"body1"}>{upperLimit}</Typography>
+          </Box>
+          <Button variant="outlined" component="label" color="secondary">
+            Upload File
+            <CSVReader
+              parserOptions={parserOptions}
+              onFileLoaded={(rawCsv) =>
+                emailDispatch({ type: "rawCsv:set", payload: { rawCsv } })
+              }
+              inputStyle={{ display: "none" }}
+            />
+          </Button>
+          {emailState.isCsvUploaded && !emailState.isValidEmails && (
+            <Box mt={1}>
+              <Typography color={"error"}>
+                Column values are not valid email. Maybe you should exclude
+                header on below CSV configs or change column position?
+              </Typography>
+            </Box>
+          )}
+          {emailState.isCsvUploaded && emailState.emailList.length === 0 && (
+            <Box mt={1}>
+              <Typography color={"error"}>CSV is empty</Typography>
+            </Box>
+          )}
+        </Box>
         {emailState.isCsvUploaded &&
-        emailState.isValidEmails &&
-        emailState.emailList.length > 0 ? (
-          <>
-            <Box mt={4} mb={2}>
-              <Typography>Total Email Addresses</Typography>
-              <Typography variant="h2">
-                {emailState.emailList.length}
-              </Typography>
-            </Box>
-            <Box my={2}>
-              {upperLimit < emailState.emailList.length && (
-                <Box mt={1}>
-                  <Typography color={"error"}>
-                    Address number exceeds upper limit.
-                  </Typography>
-                </Box>
-              )}
-            </Box>
-          </>
-        ) : (
-          <Box my={2}>
-            <Box display="flex" alignItems="baseline" mb={1}>
-              <Typography variant={"caption"} style={{ paddingRight: 8 }}>
-                File type:
-              </Typography>
-              <Typography variant={"body1"}>CSV</Typography>
-            </Box>
-            <Box display="flex" alignItems="baseline" mb={1}>
-              <Typography variant={"caption"} style={{ paddingRight: 8 }}>
-                Email number limit:
-              </Typography>
-              <Typography variant={"body1"}>{upperLimit}</Typography>
-            </Box>
-            <Button variant="outlined" component="label" color="secondary">
-              Upload File
-              <CSVReader
-                parserOptions={parserOptions}
-                onFileLoaded={(rawCsv) =>
-                  emailDispatch({ type: "rawCsv:set", payload: { rawCsv } })
-                }
-                inputStyle={{ display: "none" }}
-              />
-            </Button>
-            {emailState.isCsvUploaded && !emailState.isValidEmails && (
-              <Box mt={1}>
-                <Typography color={"error"}>
-                  Column values are not valid email. Maybe you should exclude
-                  header on below CSV configs or change column position?
+          emailState.isValidEmails &&
+          emailState.emailList.length > 0 && (
+            <>
+              <Box mt={4} mb={2}>
+                <Typography>Total Email Addresses</Typography>
+                <Typography variant="h2">
+                  {emailState.emailList.length}
                 </Typography>
               </Box>
-            )}
-            {emailState.isCsvUploaded && emailState.emailList.length === 0 && (
-              <Box mt={1}>
-                <Typography color={"error"}>CSV is empty</Typography>
+              <Box my={2}>
+                {upperLimit < emailState.emailList.length && (
+                  <Box mt={1}>
+                    <Typography color={"error"}>
+                      Address number exceeds upper limit.
+                    </Typography>
+                  </Box>
+                )}
               </Box>
-            )}
-          </Box>
-        )}
+            </>
+          )}
         <Box mt={4}>
           <Typography>CSV configs</Typography>
           <FormGroup>

--- a/frontend/packages/react-app/src/components/organisms/WalletDistributionTargets/index.tsx
+++ b/frontend/packages/react-app/src/components/organisms/WalletDistributionTargets/index.tsx
@@ -16,9 +16,7 @@
  */
 
 import React from "react";
-import { Box, Typography, Card, Button } from "@material-ui/core";
-// import DistributionTargetList from "../../molecules/DistributionTargetList";
-// import { AudiusState, AUDIUS_ACTIONS } from "../../../reducers/audius";
+import { Box, Typography, Button } from "@material-ui/core";
 import { WalletList } from "../../../interfaces";
 import { WALLET_ACTIONS } from "../../../reducers/wallet";
 
@@ -37,7 +35,52 @@ const WalletDistributionTargets: React.FC<TargetsProps> = ({
 }) => (
   <>
     <Box mb={5}>
-      {walletListState.targets.length > 0 ? (
+      <Box my={2}>
+        <Box display="flex" alignItems="baseline" mb={1}>
+          <Typography variant={"caption"} style={{ paddingRight: 8 }}>
+            File type:
+          </Typography>
+          <Typography variant={"body1"}>JSON</Typography>
+        </Box>
+        <Box display="flex" alignItems="baseline" mb={1}>
+          <Typography variant={"caption"}>Format: </Typography>
+          <Box ml={2}>
+            <Typography variant={"body1"} color={"secondary"}>
+              {`{"targets": ["walletaddress1", "walletaddress2"]}`}
+            </Typography>
+          </Box>
+        </Box>
+        <Box display="flex" alignItems="baseline" mb={1}>
+          <Typography variant={"caption"}>Target number limit: </Typography>
+          <Box ml={2}>
+            <Typography variant={"body1"}>{upperLimit}</Typography>
+          </Box>
+        </Box>
+      </Box>
+      <Button variant="outlined" component="label" color="secondary">
+        Upload File
+        <input
+          type="file"
+          accept="application/json"
+          hidden
+          onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
+            walletDispatch({
+              type: "walletlistFile:upload",
+              payload: {
+                walletlistFile: event.target.files,
+              },
+            })
+          }
+        />
+      </Button>
+      {!walletListState.fileformat && (
+        <Box mt={1}>
+          <Typography color={"error"}>
+            Set a file in the correct format.
+          </Typography>
+        </Box>
+      )}
+      {walletListState.targets.length > 0 && (
         <>
           <Box mt={4}>
             <Typography>Total Wallet Addresses</Typography>
@@ -54,54 +97,6 @@ const WalletDistributionTargets: React.FC<TargetsProps> = ({
               </Box>
             )}
           </Box>
-        </>
-      ) : (
-        <>
-          <Box my={2}>
-            <Box display="flex" alignItems="baseline" mb={1}>
-              <Typography variant={"caption"} style={{ paddingRight: 8 }}>
-                File type:
-              </Typography>
-              <Typography variant={"body1"}>JSON</Typography>
-            </Box>
-            <Box display="flex" alignItems="baseline" mb={1}>
-              <Typography variant={"caption"}>Format: </Typography>
-              <Box ml={2}>
-                <Typography variant={"body1"} color={"secondary"}>
-                  {`{"targets": ["walletaddress1", "walletaddress2"]}`}
-                </Typography>
-              </Box>
-            </Box>
-            <Box display="flex" alignItems="baseline" mb={1}>
-              <Typography variant={"caption"}>Target number limit: </Typography>
-              <Box ml={2}>
-                <Typography variant={"body1"}>{upperLimit}</Typography>
-              </Box>
-            </Box>
-          </Box>
-          <Button variant="outlined" component="label" color="secondary">
-            Upload File
-            <input
-              type="file"
-              accept="application/json"
-              hidden
-              onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
-                walletDispatch({
-                  type: "walletlistFile:upload",
-                  payload: {
-                    walletlistFile: event.target.files,
-                  },
-                })
-              }
-            />
-          </Button>
-          {!walletListState.fileformat && (
-            <Box mt={1}>
-              <Typography color={"error"}>
-                Set a file in the correct format.
-              </Typography>
-            </Box>
-          )}
         </>
       )}
     </Box>


### PR DESCRIPTION
On the Email/Wallet campaign creation page, the upload button is hidden after uploading a file successfully. 
But when a creator possibly want to upload a different file on the same page, so I updated the upload button to always appear. 
