### PR TITLE
Add end date validation

### DIFF
--- a/frontend/packages/react-app/src/components/molecules/SetupCampaignForm/index.tsx
+++ b/frontend/packages/react-app/src/components/molecules/SetupCampaignForm/index.tsx
@@ -121,9 +121,15 @@ const SetupCampaignForm: React.FC<SetupCampaignFormProps> = ({
                   "aria-label": "change date",
                 }}
                 error={
+                  distributorFormState.isEndDatePast ||
                   distributorFormState.startDate >= distributorFormState.endDate
                 }
               />
+              {distributorFormState.isEndDatePast && (
+                <FormHelperText style={{ color: "#f00", marginTop: -4 }}>
+                  End date must be future.
+                </FormHelperText>
+              )}
               {distributorFormState.startDate >=
                 distributorFormState.endDate && (
                 <FormHelperText style={{ color: "#f00", marginTop: -4 }}>

--- a/frontend/packages/react-app/src/components/molecules/steps/StartCampaignStep/index.tsx
+++ b/frontend/packages/react-app/src/components/molecules/steps/StartCampaignStep/index.tsx
@@ -70,7 +70,8 @@ const StartCampaignStep = ({
           }}
           disabled={
             distributorFormState.startDate >= distributorFormState.endDate ||
-            distributorFormState.campaignName === ""
+            distributorFormState.campaignName === "" ||
+            distributorFormState.isEndDatePast
           }
         >
           Start Campaign

--- a/frontend/packages/react-app/src/reducers/distributorForm.ts
+++ b/frontend/packages/react-app/src/reducers/distributorForm.ts
@@ -62,6 +62,7 @@ export interface createCampaignState {
   tokenAddress: string;
   distributorType: DistributorTypes | "";
   dialog: DialogStatus;
+  isEndDatePast: boolean;
 }
 
 export const distributorFormReducer = (
@@ -94,7 +95,10 @@ export const distributorFormReducer = (
     }
     case "endDate:set": {
       const endDate = Number(action.payload.endDate);
-      return { ...state, endDate: endDate };
+      const today = new Date();
+      today.setHours(0, 0, 0, 0);
+      const isEndDatePast = endDate <= today.getTime();
+      return { ...state, endDate: endDate, isEndDatePast };
     }
     case "token:approve": {
       return { ...state, approveRequest: action.payload.approveRequest };
@@ -138,4 +142,5 @@ export const distributorFormInitialState: createCampaignState = {
   tokenAddress: "",
   distributorType: "",
   dialog: "nothing",
+  isEndDatePast: false,
 };

--- a/frontend/packages/react-app/src/utils/mockData.ts
+++ b/frontend/packages/react-app/src/utils/mockData.ts
@@ -262,6 +262,7 @@ export const distributorFormState: createCampaignState = {
   tokenAddress: "0x9AF70Ab10f94fEAF59B00B2cC20C7AE57e21954e",
   distributorType: "",
   dialog: "nothing",
+  isEndDatePast: false,
 };
 
 export const audiusTarget: Target = {


### PR DESCRIPTION
Add validation for a campaign end date. 
If an end date is past or today, it's disabled to create a campaign. 