### PR TITLE
Fix frontend issues

### DIFF
--- a/frontend/packages/react-app/src/components/molecules/WaitingProcessDialog/index.tsx
+++ b/frontend/packages/react-app/src/components/molecules/WaitingProcessDialog/index.tsx
@@ -41,7 +41,9 @@ const WaitingProcessDialog: React.FC<WaitingProcessDialogProps> = ({
       case "creating-campaign":
         if (
           state.distributorType === "email" ||
-          state.distributorType === "uuid"
+          state.distributorType === "email-nft" ||
+          state.distributorType === "uuid" ||
+          state.distributorType === "uuid-nft"
         ) {
           return [
             "If you leave from a page, you lost campaign information for fans.",

--- a/frontend/packages/react-app/src/components/organisms/CampaignDetailForCreatorProps/index.tsx
+++ b/frontend/packages/react-app/src/components/organisms/CampaignDetailForCreatorProps/index.tsx
@@ -108,7 +108,7 @@ const CampaignDetailForCreator: React.FC<CampaignDetailForCreatorProps> = ({
             style={{ alignItems: "center", justifyContent: "left" }}
           >
             <Item
-              title="NFT Contract Address"
+              title="Contract Address"
               text={campaignData.campaign.distributor.id}
             />
           </Box>


### PR DESCRIPTION
### Invalid title

Contract address and etherscan link is added to creator side campaign detail page, but title is always "NFT Contract Address" even for Token Distributor Detail.
So removed "NFT" from it. 

### Invalid message

> If you leave from a page, you lost campaign information for fans. And it could take time if Ethereum network is congested.

Should be shown for UUID(Email) NFT Distribution message on waiting campaign creation transaction, but following is shown instead: 

> "And it could take time if Ethereum network is congested.