### PR TITLE
Add redirection from old campaign detail to new campaign detail page

### DIFF
--- a/frontend/packages/react-app/src/App.tsx
+++ b/frontend/packages/react-app/src/App.tsx
@@ -40,6 +40,7 @@ import CreateEmailNFTCampaignPage from "./components/pages/CreateEmailNFTCampaig
 import NFTCampaignsPage from "./components/pages/NFTCampaignsPage";
 import NFTCampaignDetailPage from "./components/pages/NFTCampaignDetailPage";
 import NFTHistoryPage from "./components/pages/NFTHistoryPage";
+import OldCampaignDetailCreatorPage from "./components/pages/OldCampaignDetailCreatorPage";
 
 const App: React.FC = () => {
   return (
@@ -189,6 +190,11 @@ const App: React.FC = () => {
               <Route
                 path="/explore/token/:tokenAddress/distributors/:distributorAddress/campaigns/:campaignId"
                 component={TokenCampaignDetailPage}
+              />
+              <Route
+                exact
+                path="/explore/:tokenAddress/distributors/:distributorAddress/campaigns/:campaignId"
+                component={OldCampaignDetailCreatorPage}
               />
               <Route
                 path="/explore/token/:tokenAddress/history"

--- a/frontend/packages/react-app/src/components/pages/OldCampaignDetailCreatorPage.tsx
+++ b/frontend/packages/react-app/src/components/pages/OldCampaignDetailCreatorPage.tsx
@@ -1,0 +1,37 @@
+/*
+ *     Copyright (C) 2021 TART K.K.
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import React from "react";
+import { Redirect, RouteComponentProps } from "react-router-dom";
+
+const OldCampaignDetailCreatorPage: React.FC<
+  RouteComponentProps<{
+    tokenAddress: string;
+    distributorAddress: string;
+    campaignId: string;
+  }>
+> = (props) => {
+  return (
+    <Redirect
+      to={{
+        pathname: `/explore/token/${props.match.params.tokenAddress}/distributors/${props.match.params.distributorAddress}/campaigns/${props.match.params.campaignId}`,
+      }}
+    />
+  );
+};
+
+export default OldCampaignDetailCreatorPage;


### PR DESCRIPTION
Example:
- From: http://localhost:3000/#/explore/0xaff4481d10270f50f203e0763e2597776068cbc5/distributors/0x4dafcf19a5def888e5d64a9577bcf883e3e9d405/campaigns/10
- To: http://localhost:3000/#/explore/token/0xaff4481d10270f50f203e0763e2597776068cbc5/distributors/0x4dafcf19a5def888e5d64a9577bcf883e3e9d405/campaigns/10 (Added `/token` after `/explore` )